### PR TITLE
Fix minimum PHP version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "version": "1.0.0",
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
JetBrains IDE sets PHP language level to PHP 5.3 and shows ugly red line under most of the code in FinvoiceSettings.php because short array syntax is only allowed since PHP 5.4